### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete multi-character sanitization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6759,9 +6759,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.25",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
-      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "version": "2.10.27",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"

--- a/src/app/shop/ShopPageClient.tsx
+++ b/src/app/shop/ShopPageClient.tsx
@@ -42,7 +42,9 @@ function extractSectionTitle(longDescription: string): string {
   if (!longDescription) return "";
   const match = longDescription.match(/<h3[^>]*>([\s\S]*?)<\/h3>/i);
   if (!match) return "";
-  return match[1].replace(/<[^>]+>/g, "").trim();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(match[1], "text/html");
+  return (doc.body.textContent || "").trim();
 }
 
 interface ShopPageClientProps {

--- a/src/app/shop/ShopPageClient.tsx
+++ b/src/app/shop/ShopPageClient.tsx
@@ -42,9 +42,7 @@ function extractSectionTitle(longDescription: string): string {
   if (!longDescription) return "";
   const match = longDescription.match(/<h3[^>]*>([\s\S]*?)<\/h3>/i);
   if (!match) return "";
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(match[1], "text/html");
-  return (doc.body.textContent || "").trim();
+  return match[1].replace(/<[^>]+>/g, "").trim();
 }
 
 interface ShopPageClientProps {


### PR DESCRIPTION
Potential fix for [https://github.com/DevNinjawork998/mocktail-business-project/security/code-scanning/9](https://github.com/DevNinjawork998/mocktail-business-project/security/code-scanning/9)

Use a parser-based approach instead of regex-based HTML sanitization.  
Best fix here: parse the matched `<h3>` fragment with `DOMParser` and read `textContent`, which avoids incomplete multi-character replacement and preserves existing behavior (returning plain text).

In `src/app/shop/ShopPageClient.tsx`, update `extractSectionTitle` (around lines 41–46):
- Keep the `<h3>` extraction regex if desired.
- Replace `match[1].replace(/<[^>]+>/g, "").trim()` with parser-based extraction:
  - `const parser = new DOMParser();`
  - `const doc = parser.parseFromString(match[1], "text/html");`
  - `return (doc.body.textContent || "").trim();`

No new dependency is required, and no import changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
